### PR TITLE
Fixed the engine check to allow it to work on node 0.8x without warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "lib/ectypes",
   "engines": {
-    "node": "~0.6.12"
+    "node": ">=0.6.x"
   },
   "dependencies": {
     "underscore": "~1.3.3",


### PR DESCRIPTION
fixed node engine to support greater than or equal to 6.x
